### PR TITLE
feat: Dynamically calculate Emperor's Birthday

### DIFF
--- a/hcal_holidays.py
+++ b/hcal_holidays.py
@@ -20,7 +20,6 @@ def get_holidays(country, year):
         # Fixed holidays
         holidays.add((1, 1))  # New Year's Day
         holidays.add((2, 11))  # National Foundation Day
-        holidays.add((2, 23))  # Emperor's Birthday
         holidays.add((4, 29))  # Showa Day
         holidays.add((5, 3))  # Constitution Memorial Day
         holidays.add((5, 4))  # Greenery Day
@@ -28,6 +27,14 @@ def get_holidays(country, year):
         holidays.add((11, 3))  # Culture Day
         holidays.add((11, 23))  # Labor Thanksgiving Day
 
+        # Emperor's Birthday
+        if year <= 1988:
+            holidays.add((4, 29))  
+        elif 1989 <= year <= 2018:
+            holidays.add((12, 23))  
+        elif year >= 2020:
+            holidays.add((2, 23))
+        
         # Simple Logic for Vernal/Autumnal Equinox (Approximate)
         # These change slightly, but for a simple CLI tool, approximations or specific year logic might be needed.
         # Keeping it simple with fixed dates for now as requested for "New Year".

--- a/tests/test_hcal_holidays.py
+++ b/tests/test_hcal_holidays.py
@@ -42,6 +42,37 @@ class TestJapanHolidays(unittest.TestCase):
         self.assertNotIn((2, 12), holidays_2023)
         self.assertNotIn((2, 13), holidays_2023)
 
+    def test_emperors_birthday_showa_era(self):
+        """
+        Test Emperor's Birthday during the Showa era (pre-1989).
+        """
+        holidays_1980 = get_holidays('Japan', 1980)
+        self.assertIn((4, 29), holidays_1980, "April 29 should be Emperor's Birthday in 1980")
+
+    def test_emperors_birthday_heisei_era(self):
+        """
+        Test Emperor's Birthday during the Heisei era (1989-2018).
+        """
+        holidays_1995 = get_holidays('Japan', 1995)
+        self.assertIn((12, 23), holidays_1995, "December 23 should be Emperor's Birthday in 1995")
+        self.assertNotIn((2, 23), holidays_1995, "February 23 should not be Emperor's Birthday in 1995")
+
+    def test_no_emperors_birthday_in_2019(self):
+        """
+        Test for no Emperor's Birthday in 2019.
+        """
+        holidays_2019 = get_holidays('Japan', 2019)
+        self.assertNotIn((12, 23), holidays_2019, "There should be no Emperor's Birthday in 2019")
+        self.assertNotIn((2, 23), holidays_2019, "There should be no Emperor's Birthday in 2019")
+
+    def test_emperors_birthday_reiwa_era(self):
+        """
+        Test Emperor's Birthday during the Reiwa era (post-2020).
+        """
+        holidays_2021 = get_holidays('Japan', 2021)
+        self.assertIn((2, 23), holidays_2021, "February 23 should be Emperor's Birthday in 2021")
+        self.assertNotIn((12, 23), holidays_2021, "December 23 should not be Emperor's Birthday in 2021")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Implements the logic to correctly determine the date of the Emperor's
Birthday in Japan based on the year, following the historical changes.

- Before 1989 (Showa era): April 29
- 1989 to 2018 (Heisei era): December 23
- 2019: No Emperor's Birthday
- After 2020 (Reiwa era): February 23

Adds unit tests to verify the holiday calculation for each era.
