### PR TITLE
fix: National Foundation Day in Japan starts from 1967

### DIFF
--- a/hcal_holidays.py
+++ b/hcal_holidays.py
@@ -28,13 +28,15 @@ def get_holidays(country, year):
         second_monday_day = first_monday_day + 7
         holidays.add((1, second_monday_day))
 
-        holidays.add((2, 11))  # National Foundation Day
         holidays.add((4, 29))  # Showa Day
         holidays.add((5, 3))  # Constitution Memorial Day
         holidays.add((5, 4))  # Greenery Day
         holidays.add((5, 5))  # Children's Day
         holidays.add((11, 3))  # Culture Day
         holidays.add((11, 23))  # Labor Thanksgiving Day
+
+        if year >= 1967:
+            holidays.add((2, 11))  # National Foundation Day
 
         # Emperor's Birthday
         if year <= 1988:

--- a/tests/test_hcal_national_foundation_day.py
+++ b/tests/test_hcal_national_foundation_day.py
@@ -1,0 +1,31 @@
+import unittest
+from hcal_holidays import get_holidays
+
+class TestJapanNationalFoundationDay(unittest.TestCase):
+    """
+    Unit tests for National Foundation Day logic in Japan.
+    """
+
+    def test_national_foundation_day_before_1967(self):
+        """
+        Test that National Foundation Day is not observed before 1967.
+        """
+        holidays_1966 = get_holidays('Japan', 1966)
+        self.assertNotIn((2, 11), holidays_1966, "National Foundation Day should not be observed in 1966")
+
+    def test_national_foundation_day_from_1967(self):
+        """
+        Test that National Foundation Day is observed starting from 1967.
+        """
+        holidays_1967 = get_holidays('Japan', 1967)
+        self.assertIn((2, 11), holidays_1967, "National Foundation Day should be observed in 1967")
+
+    def test_national_foundation_day_current_year(self):
+        """
+        Test that National Foundation Day is observed in recent years.
+        """
+        holidays_2024 = get_holidays('Japan', 2024)
+        self.assertIn((2, 11), holidays_2024, "National Foundation Day should be observed in 2024")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
National Foundation Day was previously added unconditionally. It is now only added for years >= 1967.
