### PR TITLE
fix: Culture Day in Japan starts from 1955

### DIFF
--- a/hcal_holidays.py
+++ b/hcal_holidays.py
@@ -33,7 +33,6 @@ def get_holidays(country, year):
         holidays.add((5, 3))  # Constitution Memorial Day
         holidays.add((5, 4))  # Greenery Day
         holidays.add((5, 5))  # Children's Day
-        holidays.add((11, 3))  # Culture Day
         holidays.add((11, 23))  # Labor Thanksgiving Day
 
         # Emperor's Birthday
@@ -43,6 +42,9 @@ def get_holidays(country, year):
             holidays.add((12, 23))
         elif year >= 2020:
             holidays.add((2, 23))
+
+        if year >= 1955:
+            holidays.add((11, 3))  # Culture Day
 
         # Simple Logic for Vernal/Autumnal Equinox (Approximate)
         # These change slightly, but for a simple CLI tool, approximations or specific year logic might be needed.

--- a/tests/test_hcal_culture_day.py
+++ b/tests/test_hcal_culture_day.py
@@ -1,0 +1,31 @@
+import unittest
+from hcal_holidays import get_holidays
+
+class TestJapanCultureDay(unittest.TestCase):
+    """
+    Unit tests for Culture Day logic in Japan.
+    """
+
+    def test_culture_day_before_1955(self):
+        """
+        Test that Culture Day is not observed before 1955.
+        """
+        holidays_1954 = get_holidays('Japan', 1954)
+        self.assertNotIn((11, 3), holidays_1954, "Culture Day should not be observed in 1954")
+
+    def test_culture_day_from_1955(self):
+        """
+        Test that Culture Day is observed starting from 1955.
+        """
+        holidays_1955 = get_holidays('Japan', 1955)
+        self.assertIn((11, 3), holidays_1955, "Culture Day should be observed in 1955")
+
+    def test_culture_day_current_year(self):
+        """
+        Test that Culture Day is observed in recent years.
+        """
+        holidays_2024 = get_holidays('Japan', 2024)
+        self.assertIn((11, 3), holidays_2024, "Culture Day should be observed in 2024")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Culture Day was previously added unconditionally. It is now only added for years >= 1955.
