### PR TITLE
fix: update Japan holiday logic for Sports Day, Greenery Day, and Citizens' Holiday

### DIFF
--- a/hcal_holidays.py
+++ b/hcal_holidays.py
@@ -18,7 +18,12 @@ def get_holidays(country, year):
 
     if country.lower() == 'japan':
         # Fixed holidays
-        holidays.add((1, 1))  # New Year's Day
+        if year >= 1955:
+            holidays.add((1, 1))  # New Year's Day
+            holidays.add((5, 3))  # Constitution Memorial Day
+            holidays.add((5, 5))  # Children's Day
+            holidays.add((11, 3))  # Culture Day
+            holidays.add((11, 23))  # Labor Thanksgiving Day
 
         # Coming of Age Day (2nd Monday of January)
         # Happy Monday System (since 2000)
@@ -28,25 +33,40 @@ def get_holidays(country, year):
         second_monday_day = first_monday_day + 7
         holidays.add((1, second_monday_day))
 
-        holidays.add((4, 29))  # Showa Day
-        holidays.add((5, 3))  # Constitution Memorial Day
-        holidays.add((5, 4))  # Greenery Day
-        holidays.add((5, 5))  # Children's Day
-        holidays.add((11, 23))  # Labor Thanksgiving Day
-
         if year >= 1967:
             holidays.add((2, 11))  # National Foundation Day
 
         # Emperor's Birthday
-        if year <= 1988:
+        if 1955 <= year <= 1988:
             holidays.add((4, 29))
         elif 1989 <= year <= 2018:
             holidays.add((12, 23))
         elif year >= 2020:
             holidays.add((2, 23))
 
-        if year >= 1955:
-            holidays.add((11, 3))  # Culture Day
+        if year >= 2007:
+            holidays.add((4, 29))  # Showa Day
+
+        # Greenery Day
+        if 1989 <= year <= 2006:
+            holidays.add((4, 29))
+        elif year >= 2007:
+            holidays.add((5, 4))
+
+        # Sports Day (Health and Sports Day)
+        if 1966 <= year <= 1999:
+            holidays.add((10, 10))
+        elif year >= 2000:
+            if year == 2020:
+                holidays.add((7, 24))
+            elif year == 2021:
+                holidays.add((7, 23))
+            else:
+                # 2nd Monday of October
+                first_oct = datetime.date(year, 10, 1)
+                first_monday_oct = 1 + (0 - first_oct.weekday() + 7) % 7
+                second_monday_oct = first_monday_oct + 7
+                holidays.add((10, second_monday_oct))
 
         # Simple Logic for Vernal/Autumnal Equinox (Approximate)
         # These change slightly, but for a simple CLI tool, approximations or specific year logic might be needed.
@@ -60,6 +80,25 @@ def get_holidays(country, year):
                 holiday_dates.add(datetime.date(year, month, day))
             except ValueError:
                 continue
+
+        # Citizens' Holiday (Kokumin no Kyujitsu) - Sandwich Rule
+        # A day between two national holidays becomes a holiday.
+        # This rule was introduced in 1985 (first effective in 1986).
+        if year >= 1986:
+            # We need to check all days of the year
+            # For efficiency, we can just check days between existing holidays
+            sorted_dates = sorted(list(holiday_dates))
+            sandwiches = []
+            for i in range(len(sorted_dates) - 1):
+                d1 = sorted_dates[i]
+                d2 = sorted_dates[i+1]
+                if (d2 - d1).days == 2:
+                    sandwich_date = d1 + datetime.timedelta(days=1)
+                    # If it's not Sunday and not already a holiday
+                    if sandwich_date.weekday() != 6:
+                        sandwiches.append(sandwich_date)
+            for s in sandwiches:
+                holiday_dates.add(s)
 
         # Iterate over original holidays to check for Sunday rule
         # We use a sorted list of the original holidays to process them in order,

--- a/tests/test_2007_transition.py
+++ b/tests/test_2007_transition.py
@@ -1,0 +1,42 @@
+import unittest
+from hcal_holidays import get_holidays
+
+class Test2007Transition(unittest.TestCase):
+    def test_2007_holidays(self):
+        holidays_2007 = get_holidays('Japan', 2007)
+        
+        # April 29 should be Showa Day
+        self.assertIn((4, 29), holidays_2007, "Apr 29 should be a holiday (Showa Day) in 2007")
+        
+        # May 4 should be Greenery Day
+        self.assertIn((5, 4), holidays_2007, "May 4 should be a holiday (Greenery Day) in 2007")
+
+    def test_2006_holidays(self):
+        holidays_2006 = get_holidays('Japan', 2006)
+        # April 29 was Greenery Day
+        self.assertIn((4, 29), holidays_2006, "Apr 29 should be a holiday (Greenery Day) in 2006")
+        # May 4 was Citizens' Holiday
+        self.assertIn((5, 4), holidays_2006, "May 4 should be a holiday (Citizens' Holiday) in 2006")
+
+    def test_1986_holidays(self):
+        holidays_1986 = get_holidays('Japan', 1986)
+        # May 4 should be a holiday (first year of sandwich rule)
+        # May 3 (Sat), May 4 (Sun? no), May 5 (Mon)
+        # Wait, May 4, 1986:
+        # 1986-05-01 is Thursday
+        # 1986-05-03 is Saturday
+        # 1986-05-04 is Sunday
+        # 1986-05-05 is Monday
+        # If May 4 is Sunday, it's not a Citizens' Holiday (it's Sunday).
+        # Let's check 1987.
+        # 1987-05-04 is Monday. Between May 3 (Sun) and May 5 (Tue).
+        # In 1987, May 3 is Sunday, so May 4 is already a substitute holiday?
+        # Let's check 1988.
+        # 1988-05-04 is Wednesday. Between May 3 (Tue) and May 5 (Thu).
+        # 1988-05-04 should be a Citizens' Holiday.
+        holidays_1988 = get_holidays('Japan', 1988)
+        self.assertIn((5, 4), holidays_1988, "May 4 should be a holiday (Citizens' Holiday) in 1988")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_hcal_sports_day.py
+++ b/tests/test_hcal_sports_day.py
@@ -1,0 +1,50 @@
+import datetime
+import unittest
+from hcal_holidays import get_holidays
+
+class TestSportsDay(unittest.TestCase):
+    def test_sports_day_1966_1999(self):
+        # 1966: Oct 10
+        holidays_1966 = get_holidays('Japan', 1966)
+        self.assertIn((10, 10), holidays_1966, "Sports Day should be on Oct 10 in 1966")
+        
+        # 1999: Oct 10
+        holidays_1999 = get_holidays('Japan', 1999)
+        self.assertIn((10, 10), holidays_1999, "Sports Day should be on Oct 10 in 1999")
+
+    def test_sports_day_2000_happy_monday(self):
+        # 2000: Oct 1 is Sunday. 2nd Monday is Oct 9.
+        # Oct 1 (Sun), Oct 2 (Mon) -> 1st Monday. Oct 9 -> 2nd Monday.
+        holidays_2000 = get_holidays('Japan', 2000)
+        self.assertIn((10, 9), holidays_2000, "Sports Day should be on Oct 9 (2nd Mon) in 2000")
+
+        # 2019: Oct 1 is Tuesday.
+        # 1(Tu), 2(We), 3(Th), 4(Fr), 5(Sa), 6(Su), 7(Mon) -> 1st Monday.
+        # 14 -> 2nd Monday.
+        holidays_2019 = get_holidays('Japan', 2019)
+        self.assertIn((10, 14), holidays_2019, "Sports Day should be on Oct 14 in 2019")
+
+    def test_sports_day_olympics_exceptions(self):
+        # 2020: July 24
+        holidays_2020 = get_holidays('Japan', 2020)
+        self.assertIn((7, 24), holidays_2020, "Sports Day should be on July 24 in 2020")
+        # Ensure it is NOT on Oct 12 (2nd Mon of Oct 2020)
+        # Oct 1 (Th). Oct 5 (Mon), Oct 12 (Mon)
+        self.assertNotIn((10, 12), holidays_2020, "Sports Day should NOT be on Oct 12 in 2020")
+
+        # 2021: July 23
+        holidays_2021 = get_holidays('Japan', 2021)
+        self.assertIn((7, 23), holidays_2021, "Sports Day should be on July 23 in 2021")
+        # Ensure it is NOT on Oct 11 (2nd Mon of Oct 2021)
+        # Oct 1 (Fr). Oct 4 (Mon), Oct 11 (Mon)
+        self.assertNotIn((10, 11), holidays_2021, "Sports Day should NOT be on Oct 11 in 2021")
+
+    def test_sports_day_2022_return_to_happy_monday(self):
+        # 2022: Oct 1 is Sat.
+        # 1(Sa), 2(Su), 3(Mon) -> 1st Mon.
+        # 10 -> 2nd Mon.
+        holidays_2022 = get_holidays('Japan', 2022)
+        self.assertIn((10, 10), holidays_2022, "Sports Day should be on Oct 10 in 2022")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Corrected Sports Day logic: Oct 10 (1966-1999), 2nd Mon of Oct (2000+), and Olympic exceptions (2020/2021).
- Updated Greenery Day transition: Apr 29 (1989-2006) to May 4 (2007+).
- Added Citizens' Holiday (Sandwich rule) logic for days between national holidays.
- Added verification tests for Sports Day and Greenery Day transitions.
