### PR TITLE
Fix: move get_holidays() call from formatday to formatmonth

### DIFF
--- a/hcal_util.py
+++ b/hcal_util.py
@@ -129,10 +129,6 @@ class HighlightCalendar(calendar.TextCalendar):
 
         # Check for Holidays
         if self.country:
-            # Refresh holidays if year changes (though formatmonth sets curr_y)
-            # Optimization: We could cache this, but it's cheap to fetch for now.
-            self.holidays = get_holidays(self.country, self.curr_y)
-
             if (self.curr_m, day) in self.holidays:
                 return f"{self.holiday_color_code}{day_str}\033[0m"
 
@@ -159,4 +155,6 @@ class HighlightCalendar(calendar.TextCalendar):
         """
         self.curr_y = theyear
         self.curr_m = themonth
+        if self.country:
+            self.holidays = get_holidays(self.country, self.curr_y)
         return super().formatmonth(theyear, themonth, w, l)


### PR DESCRIPTION
## Summary

- `get_holidays()` was being called inside `formatday()`, which is invoked once per day cell — up to 31 times per month render
- Moved the call to `formatmonth()`, so holidays are computed exactly once per month (and once per year change in multi-month views)
- Removed the stale comment that incorrectly described this as a cheap operation

## Test plan

- [x] All 72 existing tests pass
- [x] Multi-month and multi-year rendering still correct (each `formatmonth` call fetches holidays for the correct year)

🤖 Generated with [Claude Code](https://claude.com/claude-code)