### PR TITLE
Refactor: consolidate strip_ansi into hcal_util

### DIFF
--- a/hcal
+++ b/hcal
@@ -6,21 +6,14 @@ hcal - A command-line calendar with highlighting and holiday support.
 import argparse
 import calendar
 import datetime
-import re
 import sys
 from itertools import groupby
-from hcal_util import HighlightCalendar, read_config
+from hcal_util import HighlightCalendar, read_config, strip_ansi
 
 
 MONTHS_IN_YEAR = 12
 MONTHS_PER_ROW = 3
 SPACES_BETWEEN_MONTHS = 2
-
-
-def strip_ansi(text):
-    """Strips ANSI escape codes from text."""
-    ansi_escape = re.compile(r'\x1B(?:[@-Z\\_-]|\[[0-?]*[ -/]*[@-~])')
-    return ansi_escape.sub('', text)
 
 
 def pad_line(line, width=20):

--- a/hcal_util.py
+++ b/hcal_util.py
@@ -4,6 +4,7 @@ Utility functions and classes for hcal.
 import calendar
 import datetime
 import os
+import re
 from hcal_holidays import get_holidays
 
 ANSI_COLORS = {
@@ -19,6 +20,13 @@ ANSI_COLORS = {
 DAYS_IN_WEEK = 7
 JULIAN_COL_WIDTH = 3
 DEFAULT_COL_WIDTH = 2
+
+_ANSI_ESCAPE_RE = re.compile(r'\x1B(?:[@-Z\\_-]|\[[0-?]*[ -/]*[@-~])')
+
+
+def strip_ansi(text):
+    """Strips ANSI escape codes from text."""
+    return _ANSI_ESCAPE_RE.sub('', text)
 
 
 def read_config(file_path):

--- a/tests/hcal_test_base.py
+++ b/tests/hcal_test_base.py
@@ -1,19 +1,17 @@
 """
 Common utilities for hcal tests.
 """
-import re
 import subprocess
 import sys
 import unittest
 
+from hcal_util import strip_ansi
+
+
 class HcalTestCase(unittest.TestCase):
     """Base class for hcal tests with common helpers."""
 
-    @staticmethod
-    def strip_ansi(text):
-        """Helper to strip ANSI escape codes."""
-        ansi_escape = re.compile(r'\x1B(?:[@-Z\\_-]|\[[0-?]*[ -/]*[@-~])')
-        return ansi_escape.sub('', text)
+    strip_ansi = staticmethod(strip_ansi)
 
     def run_hcal(self, *args, check=True):
         """Runs hcal with the given arguments and returns the result."""


### PR DESCRIPTION
## Summary

- `strip_ansi` was defined identically in both `hcal` (line 20) and `tests/hcal_test_base.py` (line 13)
- Moved the single authoritative definition to `hcal_util.py`
- Both `hcal` and `tests/hcal_test_base.py` now import from `hcal_util`
- Bonus: regex is now compiled once at module level (`_ANSI_ESCAPE_RE`) instead of on every call

## Test plan

- [x] All 72 existing tests pass
- [x] `self.strip_ansi(...)` interface in test classes remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)