### PR TITLE
Fix: suppress color on non-TTY output and validate month range

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+`hcal` is a `cal`-style command-line calendar that highlights today, weekends, and holidays
+using ANSI color codes. Pure Python 3.9+, **standard library only** — no runtime dependencies.
+
+## Commands
+
+Use the project venv for all tooling (pytest/pylint live there, not in system Python):
+
+```bash
+# Run the full test suite
+.venv/bin/python -m pytest tests/
+
+# Run a single test file or test
+.venv/bin/python -m pytest tests/test_hcal_holidays.py
+.venv/bin/python -m pytest tests/test_hcal.py::test_hcal_highlighting
+
+# Lint (CI gate is --fail-under=8.0 on all tracked .py files)
+.venv/bin/python -m pylint $(git ls-files '*.py') --fail-under=8.0
+
+# Run the tool directly
+./hcal              # current month
+./hcal 12 2025      # specific month/year
+./hcal 2026         # whole year
+```
+
+CI (`.github/workflows/pylint.yml`) runs pylint plus `tests/test_hcal_holidays.py` and
+`tests/test_hcal.py` on every push.
+
+## Architecture
+
+Three modules, no package — the entry point imports the other two by filename:
+
+- **`hcal`** — executable entry script. Argument parsing (`argparse`, with a manual `-h` that
+  means "no highlight", not help — `--help` is the real help flag) and all **multi-month
+  layout** logic: rendering months 3-per-row, padding lines to a fixed visual width,
+  normalizing block heights, and grouping by year with headers. Layout math accounts for ANSI
+  codes by measuring visual length via `strip_ansi`.
+- **`hcal_util.py`** — `HighlightCalendar`, a subclass of `calendar.TextCalendar`. Overrides
+  `formatday` (applies ANSI color: white-bg for today, holiday color, red Sundays, blue
+  Saturdays, and Julian day-of-year rendering) and `formatmonth` (sets `curr_y`/`curr_m` and
+  refreshes the holiday set for the year being rendered). Also `read_config` (`~/.hcalrc`,
+  `KEY=VALUE` lines) and the shared `strip_ansi` helper.
+- **`hcal_holidays.py`** — `get_holidays(country, year)` returns a set of `(month, day)` tuples.
+  Only Japan is implemented. Fixed and variable holidays are computed per-year (variable ones
+  depend on era-specific rules, e.g. Happy Monday weekday shifts, equinox astronomical
+  approximations, one-off 2020/2021 Olympics dates), then two post-processing passes run over
+  `datetime.date` objects: Citizens' Holiday (a non-holiday sandwiched between two holidays)
+  and Substitute Holiday (Monday after a Sunday holiday).
+
+### Key conventions
+
+- **Holiday correctness is year-range-sensitive.** When touching `hcal_holidays.py`, preserve
+  the `if year >= …` / `if 1955 <= year <= …` boundaries — each Japanese holiday changed
+  definition over time, and the per-holiday tests assert specific historical years.
+- **Layout assumes a per-day column width** of 2 (default) or 3 (Julian, `-j`), with the month
+  width derived in `HighlightCalendar.__init__`. Code that builds or pads output lines must
+  account for ANSI escapes by comparing `strip_ansi` length, never raw `len`.
+
+### Tests
+
+Most test files subclass `HcalTestCase` (`tests/hcal_test_base.py`), which runs the real `./hcal`
+binary as a subprocess and provides ANSI-aware assertion helpers (`assert_visual_length`,
+`assert_months_row_alignment`, etc.). Tests are run via pytest but the suite is a mix of
+`unittest.TestCase` classes and a few plain `def test_*` functions.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Run for a whole year:
 - `-3`: Display previous, current, and next month.
 - `-A, --after <n>`: Display `<n>` additional months after the specified month.
 - `-B, --before <n>`: Display `<n>` additional months before the specified month.
+- `--color <when>`: When to use color: `auto` (default, only when output is a terminal), `always`, or `never`. The `NO_COLOR` environment variable is also honored.
 - `-h`: Disable highlighting of today's date.
 - `-j`: Display Julian days (day of year).
 - `-y [year]`: Display a calendar for the specified year (defaults to current year if no year provided).

--- a/hcal
+++ b/hcal
@@ -6,6 +6,7 @@ hcal - A command-line calendar with highlighting and holiday support.
 import argparse
 import calendar
 import datetime
+import os
 import sys
 from itertools import groupby
 from hcal_util import HighlightCalendar, read_config, strip_ansi
@@ -131,6 +132,19 @@ def display_year(cal, year, extra_years=0, before_years=0):
             print()
 
 
+def should_use_color(when):
+    """Resolves the --color setting into a boolean.
+
+    'auto' (default) enables color only when stdout is a terminal and the
+    NO_COLOR environment variable is unset.
+    """
+    if when == 'always':
+        return True
+    if when == 'never':
+        return False
+    return sys.stdout.isatty() and 'NO_COLOR' not in os.environ
+
+
 def infer_year_month(args, now):
     """Infers the year and month to display based on arguments."""
     year = args.year
@@ -176,6 +190,9 @@ def main():
                         help='Display a calendar for the specified year (default: current year)')
     parser.add_argument('-j', action='store_true', dest='julian',
                         help='Display Julian days (day of year)')
+    parser.add_argument('--color', choices=['auto', 'always', 'never'], default='auto',
+                        help="When to use color: 'auto' (default, only on a terminal), "
+                             "'always', or 'never'")
     parser.add_argument('month', type=int, nargs='?', help="Month number (1-12)")
     parser.add_argument('year', type=int, nargs='?', help="Year (e.g. 2023)")
 
@@ -183,6 +200,10 @@ def main():
 
     now = datetime.datetime.now()
     year, month = infer_year_month(args, now)
+
+    if month is not None and not 1 <= month <= MONTHS_IN_YEAR:
+        print(f"hcal: illegal month value: use 1-{MONTHS_IN_YEAR}", file=sys.stderr)
+        sys.exit(1)
 
     # Read config
     config = read_config("~/.hcalrc")
@@ -192,7 +213,8 @@ def main():
     # TextCalendar instance
     cal = HighlightCalendar(calendar.SUNDAY, today=now.date(), country=country,
                             highlight_today=not args.no_highlight,
-                            holiday_color=holiday_color, julian=args.julian)
+                            holiday_color=holiday_color, julian=args.julian,
+                            color=should_use_color(args.color))
 
     if month is None:
         if args.three_months:

--- a/hcal_util.py
+++ b/hcal_util.py
@@ -64,7 +64,7 @@ class HighlightCalendar(calendar.TextCalendar):
     # pylint: disable=too-many-instance-attributes
 
     def __init__(self, firstweekday=0, today=None, country=None,
-                 highlight_today=True, holiday_color='red', julian=False):
+                 highlight_today=True, holiday_color='red', julian=False, color=True):
         """
         Initializes the HighlightCalendar.
 
@@ -75,11 +75,14 @@ class HighlightCalendar(calendar.TextCalendar):
             highlight_today (bool): Whether to highlight today's date.
             holiday_color (str): The color name for holidays.
             julian (bool): Whether to display Julian days (day of year).
+            color (bool): Whether to emit ANSI color codes at all. When False,
+                all highlighting is disabled (e.g. for non-terminal output).
         """
         # pylint: disable=too-many-arguments, too-many-positional-arguments
         super().__init__(firstweekday)
         self.today = today
         self.country = country
+        self.color = color
         self.highlight_today = highlight_today
         self.curr_y = 0
         self.curr_m = 0
@@ -118,6 +121,7 @@ class HighlightCalendar(calendar.TextCalendar):
         Returns:
             str: The formatted day string.
         """
+        # pylint: disable=too-many-return-statements
         if self.julian and day > 0:
             date_obj = datetime.date(self.curr_y, self.curr_m, day)
             day_str = str(date_obj.timetuple().tm_yday).rjust(width)
@@ -125,6 +129,10 @@ class HighlightCalendar(calendar.TextCalendar):
             day_str = super().formatday(day, weekday, width)
 
         if day == 0:
+            return day_str
+
+        # Without color, emit plain text (e.g. when output is not a terminal)
+        if not self.color:
             return day_str
 
         # Check if this is today

--- a/man/man1/hcal.1
+++ b/man/man1/hcal.1
@@ -26,6 +26,9 @@ Display \fIAFTER\fR number of months after the current month.
 .BR \-B ", " \-\-before " \fIBEFORE\fR"
 Display \fIBEFORE\fR number of months before the current month.
 .TP
+.BR \-\-color " \fIWHEN\fR"
+Control when color is used: \fBauto\fR (the default, color only when output is a terminal), \fBalways\fR, or \fBnever\fR. The \fBNO_COLOR\fR environment variable is also honored.
+.TP
 .BR \-y " [\fIYEAR\fR]"
 Display a calendar for the specified \fIYEAR\fR. If no year is provided, it defaults to the current year.
 .TP

--- a/tests/hcal_test_base.py
+++ b/tests/hcal_test_base.py
@@ -13,9 +13,17 @@ class HcalTestCase(unittest.TestCase):
 
     strip_ansi = staticmethod(strip_ansi)
 
-    def run_hcal(self, *args, check=True):
-        """Runs hcal with the given arguments and returns the result."""
+    def run_hcal(self, *args, check=True, force_color=True):
+        """Runs hcal with the given arguments and returns the result.
+
+        Tests run hcal in a subprocess (not a terminal), where color now
+        defaults to off. force_color=True (the default) passes --color=always
+        so color-dependent assertions stay deterministic; pass force_color=False
+        to exercise the default 'auto' behavior.
+        """
         cmd = [sys.executable, "./hcal"] + list(args)
+        if force_color:
+            cmd.append("--color=always")
         return subprocess.run(cmd, capture_output=True, text=True, check=check)
 
     def assert_visual_length(self, line, expected_length):

--- a/tests/test_hcal.py
+++ b/tests/test_hcal.py
@@ -17,7 +17,7 @@ def test_hcal_highlighting():
     year = now.year
 
     # Run hcal for current month/year
-    cmd = [sys.executable, "./hcal", str(month), str(year)]
+    cmd = [sys.executable, "./hcal", str(month), str(year), "--color=always"]
     result = subprocess.run(cmd, capture_output=True, text=True, check=True)
 
     # Expected ANSI code sequence for today
@@ -62,7 +62,7 @@ def test_hcal_no_highlighting_wrong_month():
         month = now.month + 1
         year = now.year
 
-    cmd = [sys.executable, "./hcal", str(month), str(year)]
+    cmd = [sys.executable, "./hcal", str(month), str(year), "--color=always"]
     result = subprocess.run(cmd, capture_output=True, text=True, check=True)
 
     ansi_start = "\033[47;30m"
@@ -82,7 +82,7 @@ def test_hcal_colors():
     # Dec 6 is Saturday (Blue).
     # Dec 7 is Sunday (Red).
 
-    cmd = [sys.executable, "./hcal", "12", "2025"]
+    cmd = [sys.executable, "./hcal", "12", "2025", "--color=always"]
     result = subprocess.run(cmd, capture_output=True, text=True, check=True)
     output = result.stdout
 

--- a/tests/test_hcal_flags.py
+++ b/tests/test_hcal_flags.py
@@ -44,5 +44,37 @@ class TestHcalFlags(HcalTestCase):
         self.assertTrue("\033[31m" in output or "\033[34m" in output,
                         "Weekend colors should still be present")
 
+    def test_illegal_month_exits_with_error(self):
+        """Test that an out-of-range month fails cleanly instead of tracebacking."""
+        result = self.run_hcal("0", check=False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("illegal month value", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_no_color_when_not_a_terminal(self):
+        """Test that color is disabled by default when stdout is not a tty."""
+        now = datetime.datetime.now()
+        # force_color=False -> rely on default --color=auto in a piped subprocess
+        result = self.run_hcal(str(now.month), str(now.year), force_color=False)
+
+        self.assertNotIn("\033[", result.stdout,
+                         "ANSI codes should be absent when output is not a terminal")
+
+    def test_color_never_disables_color(self):
+        """Test that --color=never suppresses all ANSI codes."""
+        result = self.run_hcal("--color=never", "12", "2025", force_color=False)
+
+        self.assertNotIn("\033[", result.stdout,
+                         "ANSI codes should be absent with --color=never")
+
+    def test_color_always_enables_color(self):
+        """Test that --color=always emits ANSI codes even when piped."""
+        result = self.run_hcal("--color=always", "12", "2025", force_color=False)
+
+        self.assertIn("\033[", result.stdout,
+                      "ANSI codes should be present with --color=always")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hcal_holiday_color.py
+++ b/tests/test_hcal_holiday_color.py
@@ -35,7 +35,7 @@ class TestHcalHolidayColor(unittest.TestCase):
             config_file.write("holiday_color=green\n")
 
         # Run hcal for Jan 2024 (Jan 1 is holiday in JP, and it is a Monday)
-        cmd = [sys.executable, self.hcal_path, "1", "2024"]
+        cmd = [sys.executable, self.hcal_path, "1", "2024", "--color=always"]
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
 
         # Jan 1 is New Year's Day, should be green (\033[32m)
@@ -50,7 +50,7 @@ class TestHcalHolidayColor(unittest.TestCase):
             config_file.write("holiday_color=blue\n")
 
         # Run hcal for Jan 2024
-        cmd = [sys.executable, self.hcal_path, "1", "2024"]
+        cmd = [sys.executable, self.hcal_path, "1", "2024", "--color=always"]
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
 
         # Jan 1 should be blue (\033[34m)
@@ -62,7 +62,7 @@ class TestHcalHolidayColor(unittest.TestCase):
         with open(os.path.join(self.test_dir, ".hcalrc"), "w", encoding="utf-8") as config_file:
             config_file.write("country=Japan\n")
 
-        cmd = [sys.executable, self.hcal_path, "1", "2024"]
+        cmd = [sys.executable, self.hcal_path, "1", "2024", "--color=always"]
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
 
         # Jan 1 should be red (\033[31m)


### PR DESCRIPTION
## Summary

Fixes two usability bugs surfaced during a project review.

- **Closes #48** — Color leaked into piped/redirected output. `hcal` now emits ANSI codes only when stdout is a terminal. Adds `--color=auto|always|never` (default `auto`) and honors the `NO_COLOR` environment variable.
- **Closes #49** — An out-of-range month (e.g. `hcal 0`) dumped a Python traceback. It now prints `hcal: illegal month value: use 1-12` to stderr and exits non-zero. The documented `>12 = year` behavior is unchanged.

## Changes

- `hcal_util.py`: `HighlightCalendar` gains a `color` flag; `formatday` returns plain text when color is off.
- `hcal`: `--color` option, `should_use_color()` resolver (tty + `NO_COLOR`), and month-range validation in `main()`.
- Tests: base `run_hcal` forces `--color=always` (subprocess is non-TTY) so existing color assertions stay deterministic; same for the color tests that build their own subprocess. New tests cover no-color-when-piped, `--color=never`/`always`, and the illegal-month path.
- Docs: README and man page document `--color`.

## Verification

- `.venv/bin/python -m pytest tests/` → 76 passed
- `pylint` → 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)