### PR TITLE
Perf: cache holidays per-year in HighlightCalendar

### DIFF
--- a/hcal_util.py
+++ b/hcal_util.py
@@ -84,6 +84,7 @@ class HighlightCalendar(calendar.TextCalendar):
         self.curr_y = 0
         self.curr_m = 0
         self.holidays = set()
+        self._holiday_cache = {}
         self.holiday_color_code = ANSI_COLORS.get(holiday_color.lower(), ANSI_COLORS['red'])
         self.julian = julian
 
@@ -164,5 +165,9 @@ class HighlightCalendar(calendar.TextCalendar):
         self.curr_y = theyear
         self.curr_m = themonth
         if self.country:
-            self.holidays = get_holidays(self.country, self.curr_y)
+            # Holidays only depend on the year, so cache per-year to avoid
+            # recomputing for every month of a multi-month or full-year view.
+            if theyear not in self._holiday_cache:
+                self._holiday_cache[theyear] = get_holidays(self.country, theyear)
+            self.holidays = self._holiday_cache[theyear]
         return super().formatmonth(theyear, themonth, w, l)

--- a/tests/test_hcal_holiday_cache.py
+++ b/tests/test_hcal_holiday_cache.py
@@ -1,0 +1,47 @@
+"""
+Tests for the per-year holiday caching in HighlightCalendar.
+"""
+import calendar
+import datetime
+import unittest
+from unittest import mock
+
+import hcal_util
+from hcal_util import HighlightCalendar
+
+
+class TestHolidayCache(unittest.TestCase):
+    """Holidays only depend on the year, so they should be computed once per year."""
+
+    def _make_cal(self):
+        return HighlightCalendar(calendar.SUNDAY, today=datetime.date(2024, 1, 1),
+                                 country='Japan')
+
+    def test_holidays_computed_once_per_year(self):
+        """Rendering all 12 months of a year calls get_holidays only once."""
+        cal = self._make_cal()
+        with mock.patch.object(hcal_util, 'get_holidays',
+                               wraps=hcal_util.get_holidays) as spy:
+            for month in range(1, 13):
+                cal.formatmonth(2024, month)
+            self.assertEqual(spy.call_count, 1)
+
+    def test_distinct_years_computed_separately(self):
+        """Different years are each computed once and cached independently."""
+        cal = self._make_cal()
+        with mock.patch.object(hcal_util, 'get_holidays',
+                               wraps=hcal_util.get_holidays) as spy:
+            cal.formatmonth(2024, 1)
+            cal.formatmonth(2025, 1)
+            cal.formatmonth(2024, 2)  # cached, no new call
+            self.assertEqual(spy.call_count, 2)
+
+    def test_cached_result_matches_direct_call(self):
+        """Caching must not change the holiday set that gets used."""
+        cal = self._make_cal()
+        cal.formatmonth(2024, 1)
+        self.assertEqual(cal.holidays, hcal_util.get_holidays('Japan', 2024))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

`HighlightCalendar.formatmonth` recomputed `get_holidays(country, year)` on every call, even though holidays only depend on the year. Each computation also runs two `datetime`-based post-processing passes (Citizens' Holiday + Substitute Holiday). Rendering a full year (`hcal 2026`) therefore repeated the identical computation 12 times; multi-year views scaled even worse.

This caches the result per-year on the instance, so each distinct year is computed at most once.

## Changes

- `hcal_util.py`: add a `self._holiday_cache` dict; `formatmonth` populates and reuses it keyed by year.
- `tests/test_hcal_holiday_cache.py`: new tests asserting `get_holidays` is called once per year across a full-year render, distinct years are cached independently, and the cached set matches a direct call.

## Verification

- `.venv/bin/python -m pytest tests/` → 75 passed
- `pylint` → 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)